### PR TITLE
Convert build-playground/demo-build-pipeline to Github Actions

### DIFF
--- a/.github/workflows/demo-build-pipeline.yml
+++ b/.github/workflows/demo-build-pipeline.yml
@@ -1,0 +1,23 @@
+name: build-playground/demo-build-pipeline
+on:
+  push:
+    branches:
+    - main
+jobs:
+  Job:
+    env:
+      DUMMY_DOCKER_HUB_DOCKER_USERNAME: dummy
+    runs-on: main
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+#     # This item has no matching transformer
+#     - task: GoTool@0
+#       inputs:
+#         version: '1.10'
+    - uses: docker/login-action@v1
+      with:
+        username: "${{ env.DUMMY_DOCKER_HUB_DOCKER_USERNAME }}"
+        password: "${{ secrets.DUMMY_DOCKER_HUB_DOCKER_PASSWORD }}"
+    - run: docker build . --file "Dockerfile" -t dummy_repo:${{ github.run_id }}
+    - run: docker push dummy_repo:${{ github.run_id }}


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=143) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### build-playground/demo-build-pipeline
- [ ] Ensure secret is available: `${{ secrets.DUMMY_DOCKER_HUB_DOCKER_PASSWORD }}`
- [ ] Ensure: We have replaced '**/Dockerfile'' with 'Dockerfile'. Ensure this works for you and adjust build context and docker path if needed