### PR TITLE
Convert build-playground/demo-build-pipeline to Github Actions

### DIFF
--- a/.github/workflows/demo-build-pipeline.yml
+++ b/.github/workflows/demo-build-pipeline.yml
@@ -15,13 +15,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.10'
-    - uses: Azure/login@v1
-      with:
-        creds: "${{ secrets.AZURE_CREDENTIALS }}"
-    - uses: Azure/get-keyvault-secrets@v1
-      with:
-        keyvault: variable-group
-        secrets: "*"
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=143) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### build-playground/demo-build-pipeline
- [ ] Ensure a runner with the following labels exists: mechamachine, X86