### PR TITLE
Convert build-playground/demo-build-pipeline to Github Actions

### DIFF
--- a/.github/workflows/demo-build-pipeline.yml
+++ b/.github/workflows/demo-build-pipeline.yml
@@ -1,0 +1,27 @@
+name: build-playground/demo-build-pipeline
+on:
+  push:
+    branches:
+    - main
+jobs:
+  Job:
+    runs-on:
+      - mechamachine
+      - X86
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.10'
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: "${{ secrets.MY_OWN_DOCKER_HUB_USERNAME }}"
+        password: "${{ secrets.MY_OWN_DOCKER_HUB_ACCESS_TOKEN }}"
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        file: "**/Dockerfile"
+        push: true


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=143) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### build-playground/demo-build-pipeline
- [ ] Ensure a runner with the following labels exists: mechamachine, X86