### PR TITLE
Convert build-playground/begonaguereca/demo to Github Actions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,29 @@
+name: build-playground/begonaguereca/demo
+on:
+  push:
+    branches:
+    - build
+env:
+  OLD: SECRET
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - MyPool
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Run a one-line script
+      run: echo Hello, world!
+#     # This item has no matching transformer
+#     - task: GoTool@0
+#       inputs:
+#         version: '1.10'
+    - uses: Azure/login@v1
+      with:
+        creds: "${{ secrets.AZURE_CREDENTIALS }}"
+    # The Azure Function App does not accept glob patterns. Consider updating the package path.
+    - uses: Azure/functions-action@v1
+      with:
+        app-name: demo
+        package: "${{ github.workspace }}/**/*.zip"


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=169) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### build-playground/begonaguereca/demo
- [ ] Ensure a runner with the following labels exists: MyPool
- [ ] Ensure secret is available: `${{ secrets.AZURE_CREDENTIALS }}`