### PR TITLE
Convert build-playground/integration-tests/yaml/step_param_under_job_and_stage to GitHub Actions

### DIFF
--- a/.github/workflows/step_param_under_job_and_stage.yml
+++ b/.github/workflows/step_param_under_job_and_stage.yml
@@ -1,0 +1,12 @@
+name: build-playground/integration-tests/yaml/step_param_under_job_and_stage
+on:
+  workflow_dispatch:
+jobs:
+  job_1:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - uses: valet-testing/build-playground/Begona-test/.github/actions/integration_tests_templates_step_template_step_parameter
+      with:
+        message: testing


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=353) :tada: