### PR TITLE
Convert build-playground/valet-testing-integration.azure-devops-example to GitHub Actions

### DIFF
--- a/.github/workflows/valet-testing-integration.azure-devops-example.yml
+++ b/.github/workflows/valet-testing-integration.azure-devops-example.yml
@@ -1,0 +1,22 @@
+name: build-playground/valet-testing-integration.azure-devops-example
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+    paths:
+    - "**/*.rb"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - name: Run a one-line script
+      run: echo Hello, world!
+    - name: Run a multi-line script
+      run: |-
+        echo Add other tasks to build, test, and deploy your project.
+        echo See https://aka.ms/yaml


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=47) :tada: