### PR TITLE
Convert valet-testing/build-playground to GitHub Actions

### DIFF
--- a/.github/workflows/build-playground.yml
+++ b/.github/workflows/build-playground.yml
@@ -1,0 +1,15 @@
+name: valet-testing/build-playground
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - name: Run a one-line script
+      run: echo Hello, world!
+    - name: Run a multi-line script
+      run: |-
+        echo Add other tasks to build, test, and deploy your project.
+        echo See https://aka.ms/yaml


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=251) :tada: