### PR TITLE
Convert build-playground/integration-tests/yaml/conditional_steps to GitHub Actions

### DIFF
--- a/.github/workflows/conditional_steps.yml
+++ b/.github/workflows/conditional_steps.yml
@@ -1,0 +1,28 @@
+name: build-playground/integration-tests/yaml/conditional_steps
+on:
+  workflow_dispatch:
+    inputs:
+      experimentalTemplate:
+        description: Use experimental build process?
+        default: false
+        type: boolean
+        required: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - uses: begonaguereca/importer/.github/actions/integration_tests_templates_simple_step
+      if: true == true && false == false
+#     # 'elseif' was not transformed because there is no suitable equivalent in GitHub Actions
+#     - task: composite_action
+#       inputs:
+#         path: "./templates/simple_step.yml"
+#         parameters:
+#       condition: elseif eq(parameters.experimentalTemplate, false)
+    - uses: begonaguereca/importer/.github/actions/integration_tests_templates_simple_step
+      if: '"banannas" == "banannas" && !(true == true && false == false)'
+    - uses: begonaguereca/importer/.github/actions/integration_tests_templates_simple_step
+      if: '"apples" == "apples" && (!(true == true && false == false) && !("banannas" == "banannas"))'
+    - uses: begonaguereca/importer/.github/actions/integration_tests_templates_simple_step


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=251) :tada: