### PR TITLE
Convert build-playground/build-playground_(21) to GitHub Actions

### DIFF
--- a/.github/workflows/build-playground_(21).yml
+++ b/.github/workflows/build-playground_(21).yml
@@ -1,0 +1,17 @@
+name: build-playground/build-playground_(21)
+on:
+  push:
+    branches:
+    - "*"
+jobs:
+  templates_jobs:
+    name: templates_jobs
+    uses: begonaguereca/importer/.github/workflows/templates_jobs.yml
+  alt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - run: echo This script runs before the template's steps.
+    - uses: begonaguereca/importer/.github/actions/templates_step
+    - run: echo This step runs after the template's steps.


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=452) :tada: